### PR TITLE
msbuild: copy dll to targetdir instead of projectdir

### DIFF
--- a/KAMI/KAMI.csproj
+++ b/KAMI/KAMI.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars64.bat&quot; &amp;&amp; cd &quot;$(SolutionDir)pcsx2_ipc\bindings\c&quot; &amp;&amp; meson build &amp;&amp; cd build &amp;&amp; ninja &amp;&amp; xcopy pcsx2_ipc_c.dll &quot;$(ProjectDir)&quot; /Y" />
+    <Exec Command="call &quot;$(DevEnvDir)..\..\VC\Auxiliary\Build\vcvars64.bat&quot; &amp;&amp; cd &quot;$(SolutionDir)pcsx2_ipc\bindings\c&quot; &amp;&amp; meson build &amp;&amp; cd build &amp;&amp; ninja &amp;&amp; xcopy pcsx2_ipc_c.dll &quot;$(TargetDir)&quot; /Y" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Adjusts the main csproj to copy the pcsx2_ipc_c.dll to the targetdir instead of the projectdir. This improves the first-time compilation experience.