### PR TITLE
games: add support for Persona 5

### DIFF
--- a/KAMI/GameManager.cs
+++ b/KAMI/GameManager.cs
@@ -11,7 +11,10 @@ namespace KAMI
         {
             switch (id)
             {
-
+                case "BLUS31604":
+                case "BLES02247":
+                case "NPUB31848":
+                case "NPEB02436": return new Persona5PS3(ipc);
                 case "BCES00052": return new RatchetToD(ipc);
                 case "BCES01503": return new Ratchet3PS3(ipc);
                 case "BCES01743": return new Killzone1PS3(ipc);

--- a/KAMI/Games/IGame.cs
+++ b/KAMI/Games/IGame.cs
@@ -15,7 +15,7 @@ namespace KAMI.Games
     {
         protected IntPtr m_ipc;
         protected TCamera m_camera;
-        public float SensModifier { get; set; } = 0.005f;
+        public float SensModifier { get; set; } = 0.003f;
 
         public Game(IntPtr ipc)
         {

--- a/KAMI/Games/Persona5PS3.cs
+++ b/KAMI/Games/Persona5PS3.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using KAMI.Cameras;
+using KAMI.Utilities;
+
+namespace KAMI.Games
+{
+    public class Persona5PS3 : Game<HAVACamera>
+    {
+        const uint BaseAddress = 0x010DD540;
+
+        DerefChain m_hor;
+        DerefChain m_vert;
+
+        public Persona5PS3(IntPtr ipc) : base(ipc)
+        {
+            var baseChain = DerefChain.CreateDerefChain(ipc, BaseAddress, 0x34, 0xD8, 0x34);
+            m_hor = baseChain.Chain(0x170);
+            m_vert = baseChain.Chain(0x174);
+        }
+
+        public override void UpdateCamera(int diffX, int diffY)
+        {
+            if (DerefChain.VerifyChains(m_hor, m_vert))
+            {
+                // the values are in degrees, so they need a deg -> rad conversion
+                m_camera.Hor = (float)(IPCUtils.ReadFloat(m_ipc, (uint)m_hor.Value) * (Math.PI / 180));
+                m_camera.Vert = (float)(IPCUtils.ReadFloat(m_ipc, (uint)m_vert.Value) * (Math.PI / 180));
+
+                // the vertical value needs to be clamped, these values seemed reasonable
+                m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
+                m_camera.Vert = (float)Math.Clamp(m_camera.Vert, -60f * (Math.PI / 180), 75f * (Math.PI / 180));
+
+                // the new values are in radians, so they need a rad -> deg conversion
+                IPCUtils.WriteFloat(m_ipc, (uint)m_hor.Value, (float)(m_camera.Hor * (180 / Math.PI)));
+                IPCUtils.WriteFloat(m_ipc, (uint)m_vert.Value, (float)(m_camera.Vert * (180 / Math.PI)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This changeset adds support for the PS3 game Persona 5. [Video demo.](https://www.youtube.com/watch?v=1ET8BtrSPwE) Massive thanks to @tellowkrinkle for coaching my way through the rather tedious RE'ing process, especially considering this was my first time doing such a thing. Without his help this hook wouldn't exist, or would work way worse.

**Known issues/limitations:**

- the distance between the main character and the camera cannot be controlled, and isn't auto-adjusted either. Normally the game does this on it's own, but it also changes the path the camera travels through and makes it take a different amount of time to move depending on its location. This is desirable with controllers, much less so here;
- the camera cannot be moved when it's in a special, "limited-movement" mode. It can otherwise be nudged with analog sticks when using a controller, so this is also a defect;
- the direction the character is moving can forcefully readjust the camera, which can be jarring. This is actually a desired behaviour when on controllers, though games sometimes offer you the ability to turn this off. This game doesn't, so it'd need further research to achieve it, if even possible.

I'd say the first two are minor issues, and the last one is at best a medium severity. I consider the way the hook works as-is a massive improvement over controllers, so imo it's a job done. Enjoy!

**Implementation notes:**

- I wasn't sure if I should create a new Camera class or not just for handling degree <-> radian memes, so for now it uses the radian based class and converts as needed.
- I have the NPEB02436 version, and hurb tested BLUS31604, so these area already added to be available for hooking. Pre-emptively added support for the NPUB and the BLES release too. JP versions need testing, if anyone can, please reach out.
- I also tuned the sensitivity a little, as it was too speedy.