### PR TITLE
CI: fix core dependency (PINE) not building and bundling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,12 +34,15 @@ jobs:
       #    chmod +x *.sh
       #    sudo apt-get -y update
       #    sudo apt-get -y install meson ninja-build
-      - name: Setup (Windows)
+      - name: Build PINE (Windows)
         if: matrix.runs-on == 'windows-latest'
-        run: choco install meson ninja
-      - name: Build deps
-        run: ./build_deps${{ matrix.file_extension }}
-      - name: Build
+        run: |
+          python -m pip install meson ninja
+          cd "pine/bindings/c"
+          meson setup "build" --vsenv
+          meson compile -C "build"
+          copy "build/pine_c.dll" "../../../KAMI.Core"
+      - name: Build KAMI
         run: ./build_publish${{ matrix.file_extension }}
       - uses: actions/upload-artifact@v2
         with:

--- a/build_deps.bat
+++ b/build_deps.bat
@@ -1,4 +1,3 @@
-refreshenv
 cd "pine/bindings/c"
 meson "build"
 cd "build"


### PR DESCRIPTION
Fixes PINE not building and bundling with the final archive. 