### PR TITLE
Handle PCSX2 BIOS 'serials'

### DIFF
--- a/KAMI.Core/GameManager.cs
+++ b/KAMI.Core/GameManager.cs
@@ -1,12 +1,15 @@
 ﻿using KAMI.Core.Games;
 using System;
+using System.Text.RegularExpressions;
 
 namespace KAMI.Core
 {
     public static class GameManager
     {
+        const string PCSX2BiosPattern = @"\d{8}-\d{6}";
         public static IGame GetGame(IntPtr ipc, string id, string version)
         {
+            if (Regex.IsMatch(id, PCSX2BiosPattern)) return new MockGame();
             switch (id)
             {
                 case "BLUS31006":

--- a/KAMI.Core/Games/MockGame.cs
+++ b/KAMI.Core/Games/MockGame.cs
@@ -1,0 +1,15 @@
+﻿namespace KAMI.Core.Games
+{
+    internal class MockGame : IGame
+    {
+        public float SensModifier { get; set; }
+
+        public void InjectionStart()
+        {
+        }
+
+        public void UpdateCamera(int diffX, int diffY)
+        {
+        }
+    }
+}


### PR DESCRIPTION
PCSX2 nowdays reports some date string or something when booting the bios (happens for a few seconds every boot).
When this happens there's no need to throw and show the user some exception MessageBox, just pretend we support it with a mock implementation that does nothing.