### PR TITLE
Support for Metal Gear Solid 4

### DIFF
--- a/KAMI.Core/GameManager.cs
+++ b/KAMI.Core/GameManager.cs
@@ -42,6 +42,12 @@ namespace KAMI.Core
                 case "SCUS-97353": return new Ratchet3PS2(ipc);
                 case "SCUS-97465": return new RatchetDLPS2(ipc);
                 case "SLUS-21376": return new BlackPS2(ipc);
+                case "NPUB31633":
+                case "NPEB02182":
+                case "NPJB00698":
+                case "BLES00246":
+                case "BLJM67001":
+                case "BLUS30109": return new MetalGearSolid4(ipc, id, version);
                 default:
                     throw new NotImplementedException($"Game with id '{id}' not implemented");
             }

--- a/KAMI.Core/Games/MetalGearSolid4.cs
+++ b/KAMI.Core/Games/MetalGearSolid4.cs
@@ -1,0 +1,65 @@
+﻿using KAMI.Core.Cameras;
+using KAMI.Core.Utilities;
+using System;
+
+namespace KAMI.Core.Games
+{
+    public class MetalGearSolid4 : Game<HAVACamera>
+    {
+        uint m_base_address;
+        uint m_camera_address;
+
+
+        public MetalGearSolid4(IntPtr ipc, string id, string version) : base(ipc)
+        {
+            (m_base_address, m_camera_address) = id switch
+            {
+                // disc
+                "BLES00246" or "BLJM67001" or "BLUS30109" when version is "02.00" => (0x559b24u, 0x559ac0u),
+                // digital
+                "NPUB31633" or "NPEB02182" or "NPJB00698" when version is "02.00" => (0x5496a4u, 0x549640u),
+                _ => throw new NotImplementedException($"{nameof(MetalGearSolid4)} ['{id}', v'{version}'] is not implemented"),
+            };
+        }
+
+        public override void UpdateCamera(int diffX, int diffY)
+        {
+            uint cameraChannel = m_camera_address + 0x60;
+            uint flag = IPCUtils.ReadU32(m_ipc, cameraChannel);
+
+            if ((flag & 0x00008000) == 0)
+            {
+                return;
+            }
+
+            uint pCameraCurrent = IPCUtils.ReadU32(m_ipc, cameraChannel + 0x10);
+            IPCUtils.WriteFloat(m_ipc, pCameraCurrent + 0x188, 1.00f); // disable camera interpolation
+
+            // shoulder
+            uint pCameraShoulder = IPCUtils.ReadU32(m_ipc, m_camera_address + 0x18) + 0x170 + 0x4C;
+            m_camera.Vert = IPCUtils.ReadFloat(m_ipc, pCameraShoulder);
+            m_camera.Hor = IPCUtils.ReadFloat(m_ipc, pCameraShoulder + 0x4);
+            m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
+            IPCUtils.WriteFloat(m_ipc, pCameraShoulder, m_camera.Vert);
+            IPCUtils.WriteFloat(m_ipc, pCameraShoulder + 0x4, m_camera.Hor);
+
+            // fpv
+            uint pCameraFPV = IPCUtils.ReadU32(m_ipc, m_camera_address + 0x18) - 0x70;
+            m_camera.Vert = IPCUtils.ReadFloat(m_ipc, pCameraFPV);
+            m_camera.Hor = IPCUtils.ReadFloat(m_ipc, pCameraFPV + 0x4);
+            m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
+            IPCUtils.WriteFloat(m_ipc, pCameraFPV, m_camera.Vert);
+            IPCUtils.WriteFloat(m_ipc, pCameraFPV + 0x4, m_camera.Hor);
+
+            // 3pp
+            uint pCameraTPP = IPCUtils.ReadU32(m_ipc, m_base_address + 0x4);
+            pCameraTPP = IPCUtils.ReadU32(m_ipc, pCameraTPP - 0x80) + 0x174;
+            ushort hor = IPCUtils.ReadU16(m_ipc, pCameraTPP);
+            ushort vert = IPCUtils.ReadU16(m_ipc, pCameraTPP + 0x8);
+            hor = (ushort)(hor + (-diffX * SensModifier) * 7000);
+            vert = (ushort)(vert + (diffY * SensModifier) * 7000);
+            IPCUtils.WriteU16(m_ipc, pCameraTPP + 0x0, hor);
+            IPCUtils.WriteU16(m_ipc, pCameraTPP + 0x8, vert);
+        }
+    }
+}

--- a/KAMI.Core/Games/MetalGearSolid4.cs
+++ b/KAMI.Core/Games/MetalGearSolid4.cs
@@ -6,60 +6,65 @@ namespace KAMI.Core.Games
 {
     public class MetalGearSolid4 : Game<HAVACamera>
     {
-        uint m_base_address;
-        uint m_camera_address;
-
+        uint m_camera_daemon;
 
         public MetalGearSolid4(IntPtr ipc, string id, string version) : base(ipc)
         {
-            (m_base_address, m_camera_address) = id switch
+            (m_camera_daemon) = id switch
             {
                 // disc
-                "BLES00246" or "BLJM67001" or "BLUS30109" when version is "02.00" => (0x559b24u, 0x559ac0u),
+                "BLES00246" or "BLJM67001" or "BLUS30109" when version is "02.00" => 0x559ac0u,
                 // digital
-                "NPUB31633" or "NPEB02182" or "NPJB00698" when version is "02.00" => (0x5496a4u, 0x549640u),
+                "NPUB31633" or "NPEB02182" or "NPJB00698" when version is "02.00" => 0x549640u,
                 _ => throw new NotImplementedException($"{nameof(MetalGearSolid4)} ['{id}', v'{version}'] is not implemented"),
             };
         }
 
         public override void UpdateCamera(int diffX, int diffY)
         {
-            uint cameraChannel = m_camera_address + 0x60;
-            uint flag = IPCUtils.ReadU32(m_ipc, cameraChannel);
+            uint pCameraChannel = m_camera_daemon + 0x60;
+            uint pCameraCurrent = IPCUtils.ReadU32(m_ipc, pCameraChannel + 0x10);
+            // the actual camera state (in training mode) is at 3641B3556.
+            // need to find a way to access it for each stage.
+            ushort flag = IPCUtils.ReadU16(m_ipc, m_camera_daemon + 0x7A);
 
-            if ((flag & 0x00008000) == 0)
+            if ((flag & 0x0F00) == 0x0700)
             {
-                return;
+                if ((flag & 0x0001) == 0x1)
+                {
+                    uint pCameraShoulder = IPCUtils.ReadU32(m_ipc, IPCUtils.ReadU32(m_ipc, pCameraChannel + 0x10));
+                    m_camera.Vert = IPCUtils.ReadFloat(m_ipc, pCameraShoulder + 0x15C);
+                    m_camera.Hor = IPCUtils.ReadFloat(m_ipc, pCameraShoulder + 0x160);
+                    m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
+                    IPCUtils.WriteFloat(m_ipc, pCameraShoulder + 0x15C, m_camera.Vert);
+                    IPCUtils.WriteFloat(m_ipc, pCameraShoulder + 0x160, m_camera.Hor);
+                }
+                else
+                {
+                    uint pCameraFPP = IPCUtils.ReadU32(m_ipc, pCameraChannel + 0x8);
+                    m_camera.Vert = IPCUtils.ReadFloat(m_ipc, pCameraFPP - 0xD0);
+                    m_camera.Hor = IPCUtils.ReadFloat(m_ipc, pCameraFPP - 0xCC);
+                    m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
+                    IPCUtils.WriteFloat(m_ipc, pCameraFPP - 0xD0, m_camera.Vert);
+                    IPCUtils.WriteFloat(m_ipc, pCameraFPP - 0xCC, m_camera.Hor);
+                }
             }
+            else
+            {
+                if (pCameraCurrent != 0)
+                {
+                    IPCUtils.WriteFloat(m_ipc, pCameraCurrent + 0x188, 1.00f); // disable camera interpolation
+                }
 
-            uint pCameraCurrent = IPCUtils.ReadU32(m_ipc, cameraChannel + 0x10);
-            IPCUtils.WriteFloat(m_ipc, pCameraCurrent + 0x188, 1.00f); // disable camera interpolation
-
-            // shoulder
-            uint pCameraShoulder = IPCUtils.ReadU32(m_ipc, m_camera_address + 0x18) + 0x170 + 0x4C;
-            m_camera.Vert = IPCUtils.ReadFloat(m_ipc, pCameraShoulder);
-            m_camera.Hor = IPCUtils.ReadFloat(m_ipc, pCameraShoulder + 0x4);
-            m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
-            IPCUtils.WriteFloat(m_ipc, pCameraShoulder, m_camera.Vert);
-            IPCUtils.WriteFloat(m_ipc, pCameraShoulder + 0x4, m_camera.Hor);
-
-            // fpv
-            uint pCameraFPV = IPCUtils.ReadU32(m_ipc, m_camera_address + 0x18) - 0x70;
-            m_camera.Vert = IPCUtils.ReadFloat(m_ipc, pCameraFPV);
-            m_camera.Hor = IPCUtils.ReadFloat(m_ipc, pCameraFPV + 0x4);
-            m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
-            IPCUtils.WriteFloat(m_ipc, pCameraFPV, m_camera.Vert);
-            IPCUtils.WriteFloat(m_ipc, pCameraFPV + 0x4, m_camera.Hor);
-
-            // 3pp
-            uint pCameraTPP = IPCUtils.ReadU32(m_ipc, m_base_address + 0x4);
-            pCameraTPP = IPCUtils.ReadU32(m_ipc, pCameraTPP - 0x80) + 0x174;
-            ushort hor = IPCUtils.ReadU16(m_ipc, pCameraTPP);
-            ushort vert = IPCUtils.ReadU16(m_ipc, pCameraTPP + 0x8);
-            hor = (ushort)(hor + (-diffX * SensModifier) * 7000);
-            vert = (ushort)(vert + (diffY * SensModifier) * 7000);
-            IPCUtils.WriteU16(m_ipc, pCameraTPP + 0x0, hor);
-            IPCUtils.WriteU16(m_ipc, pCameraTPP + 0x8, vert);
+                uint pCameraTPP = IPCUtils.ReadU32(m_ipc, IPCUtils.ReadU32(m_ipc, pCameraChannel + 0x8));
+                ushort hor = IPCUtils.ReadU16(m_ipc, pCameraTPP + 0x2C4);
+                ushort vert = IPCUtils.ReadU16(m_ipc, pCameraTPP + 0x2CC);
+                m_camera.Hor = (hor / 65536f) * (float)(2 * Math.PI);
+                m_camera.Vert = (vert / 65536f) * (float)(2 * Math.PI);
+                m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
+                IPCUtils.WriteU16(m_ipc, pCameraTPP + 0x2C4, (ushort)Math.Round(m_camera.Hor / (float)(2 * Math.PI) * 65536f));
+                IPCUtils.WriteU16(m_ipc, pCameraTPP + 0x2CC, (ushort)Math.Round(m_camera.Vert / (float)(2 * Math.PI) * 65536f));
+            }
         }
     }
 }

--- a/KAMI.Core/IPCUtils.cs
+++ b/KAMI.Core/IPCUtils.cs
@@ -47,6 +47,5 @@ namespace KAMI.Core
             Write(ipc, address, value, IPCCommand.MsgWrite16);
             Error = GetError(ipc);
         }
-
     }
 }

--- a/KAMI.Core/IPCUtils.cs
+++ b/KAMI.Core/IPCUtils.cs
@@ -34,5 +34,19 @@ namespace KAMI.Core
             Write(ipc, address, value, IPCCommand.MsgWrite32);
             Error = GetError(ipc);
         }
+
+        public static ushort ReadU16(IntPtr ipc, uint address)
+        {
+            ushort value = (ushort)Read(ipc, address, IPCCommand.MsgRead16);
+            Error = GetError(ipc);
+            return value;
+        }
+
+        public static void WriteU16(IntPtr ipc, uint address, ushort value)
+        {
+            Write(ipc, address, value, IPCCommand.MsgWrite16);
+            Error = GetError(ipc);
+        }
+
     }
 }


### PR DESCRIPTION
MGS4 is fairly annoying to work with because each stage is actually a completely different executable, and it turns out each executable has the camera code duplicated. So, naturally the offsets are shifted every time you enter into a new area. I was able to find the pointers for all of the camera data in the base executable, which points to the offsets in whatever the currently loaded stage is.

As for why the 3PP uses shorts instead of floats, I'm not sure. Maybe they are Halfs or something.

Enjoy :D

**Known Issues**
- The mouse does not work on the Rex stage.
- You cannot move the camera horizontally when aiming with the knife in third person.