### PR TITLE
Add scoped sensitivity to RaC3 Multiplayer and fix camera locking on gravity ramps in RaC3 Multiplayer

### DIFF
--- a/KAMI.Core/Games/IGame.cs
+++ b/KAMI.Core/Games/IGame.cs
@@ -8,6 +8,7 @@ namespace KAMI.Core.Games
         public void InjectionStart();
         public void UpdateCamera(int diffX, int diffY);
         public float SensModifier { get; set; }
+        public float ScopedSensModifier { get; set; }
     }
 
     public abstract class Game<TCamera> : IGame where TCamera : ICamera, new()
@@ -15,6 +16,7 @@ namespace KAMI.Core.Games
         protected IntPtr m_ipc;
         protected TCamera m_camera;
         public float SensModifier { get; set; } = 0.003f;
+        public float ScopedSensModifier { get; set; } = 1f;
 
         public Game(IntPtr ipc)
         {

--- a/KAMI.Core/Games/MockGame.cs
+++ b/KAMI.Core/Games/MockGame.cs
@@ -3,6 +3,7 @@
     internal class MockGame : IGame
     {
         public float SensModifier { get; set; }
+        public float ScopedSensModifier { get; set; }
 
         public void InjectionStart()
         {

--- a/KAMI.Core/Games/Ratchet3PS2.cs
+++ b/KAMI.Core/Games/Ratchet3PS2.cs
@@ -100,10 +100,10 @@ namespace KAMI.Core.Games
                 vertDiff *= ScopedSensModifier;
             }
 
-            m_camera.Update(horDiff, vertDiff);
+            // m_camera.Update(horDiff, vertDiff);
 
-            IPCUtils.WriteFloat(m_ipc, m_addressHor, m_camera.Hor);
-            IPCUtils.WriteFloat(m_ipc, m_addressVert, m_camera.Vert);
+            // IPCUtils.WriteFloat(m_ipc, m_addressHor, m_camera.Hor);
+            // IPCUtils.WriteFloat(m_ipc, m_addressVert, m_camera.Vert);
 
             // Gravity-ramp directional camera update using character up vector
             // Applied to both single player and multiplayer
@@ -117,9 +117,9 @@ namespace KAMI.Core.Games
         private void UpdateGravityRampCamera(float horDiff, float vertDiff)
         {
             // Read current gravity camera direction (unit-ish vector)
-            float camX = (float)Math.Round(IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB0), 5);
-            float camY = (float)Math.Round(IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB4), 5);
-            float camZ = (float)Math.Round(IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB8), 5);
+            float camX = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB0);
+            float camY = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB4);
+            float camZ = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB8);
 
             // Read character up vector U = (Ux, Uy, Uz)
             float Ux;

--- a/KAMI.Core/Games/Ratchet3PS2.cs
+++ b/KAMI.Core/Games/Ratchet3PS2.cs
@@ -5,7 +5,7 @@ namespace KAMI.Core.Games
     public class Ratchet3PS2 : RatchetOGBase
     {
         private uint m_addressScoped;
-        private bool isScoped;
+        bool is_single_player;
 
         public Ratchet3PS2(IntPtr ipc) : base(ipc)
         {
@@ -14,22 +14,12 @@ namespace KAMI.Core.Games
         public override void UpdateCamera(int diffX, int diffY)
         {
             uint mp_map_id = IPCUtils.ReadU32(m_ipc, 0x001F8528);
-            if (mp_map_id < 40) // must be SP
+            is_single_player = mp_map_id < 40;
+            if (is_single_player) // must be SP
             {
                 m_addressHor = 0x1A6160;
                 m_addressVert = 0x1A6180;
                 m_addressScoped = 0x1A71C5;
-
-                isScoped = IPCUtils.ReadU8(m_ipc, m_addressScoped) != 0;
-
-                if (isScoped)
-                {
-                    diffX = (int)(diffX * ScopedSensModifier);
-                    diffY = (int)(diffY * ScopedSensModifier);
-                }
-
-                base.UpdateCamera(diffX, diffY);
-                return;
             }
             else
             {
@@ -96,10 +86,11 @@ namespace KAMI.Core.Games
                         break;
                 }
             }
+
             m_camera.Hor = IPCUtils.ReadFloat(m_ipc, m_addressHor);
             m_camera.Vert = IPCUtils.ReadFloat(m_ipc, m_addressVert);
 
-            isScoped = IPCUtils.ReadU8(m_ipc, m_addressScoped) != 0;
+            bool isScoped = IPCUtils.ReadU8(m_ipc, m_addressScoped) != 0;
             float horDiff = -diffX * SensModifier;
             float vertDiff = diffY * SensModifier;
 
@@ -115,15 +106,33 @@ namespace KAMI.Core.Games
             IPCUtils.WriteFloat(m_ipc, m_addressVert, m_camera.Vert);
 
             // Gravity-ramp directional camera update using character up vector
+            // Applied to both single player and multiplayer
+            UpdateGravityRampCamera(horDiff, vertDiff);
+        }
+
+        private void UpdateGravityRampCamera(float horDiff, float vertDiff)
+        {
             // Read current gravity camera direction (unit-ish vector)
             float camX = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB0);
             float camY = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB4);
             float camZ = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB8);
 
             // Read character up vector U = (Ux, Uy, Uz)
-            float Ux = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xA8);
-            float Uy = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0x98);
-            float Uz = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xB8);
+            float Ux;
+            float Uy;
+            float Uz;
+            if (is_single_player)
+            {
+                Ux = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xC8);
+                Uy = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xB8);
+                Uz = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xD8);
+            }
+            else
+            {
+                Ux = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xA8);
+                Uy = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0x98);
+                Uz = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xB8);
+            }
 
             // Normalize U
             float uLen = MathF.Sqrt(Ux * Ux + Uy * Uy + Uz * Uz);
@@ -147,21 +156,6 @@ namespace KAMI.Core.Games
                 camX /= dLen; camY /= dLen; camZ /= dLen;
             }
 
-            // Build right vector R = normalize(U x D)
-            float Rx = Uy * camZ - Uz * camY;
-            float Ry = Uz * camX - Ux * camZ;
-            float Rz = Ux * camY - Uy * camX;
-            float rLen = MathF.Sqrt(Rx * Rx + Ry * Ry + Rz * Rz);
-            if (rLen < 1e-4f)
-            {
-                // Degenerate (looking straight up/down) – pick any right perpendicular to U
-                Rx = 1f; Ry = 0f; Rz = 0f;
-            }
-            else
-            {
-                Rx /= rLen; Ry /= rLen; Rz /= rLen;
-            }
-
             // 1) Yaw around up vector U by horDiff
             var (yawX, yawY, yawZ) = RotateAroundAxis(
                 camX, camY, camZ,
@@ -169,10 +163,10 @@ namespace KAMI.Core.Games
                 horDiff);
 
             // Recompute right after yaw
-            Rx = Uy * yawZ - Uz * yawY;
-            Ry = Uz * yawX - Ux * yawZ;
-            Rz = Ux * yawY - Uy * yawX;
-            rLen = MathF.Sqrt(Rx * Rx + Ry * Ry + Rz * Rz);
+            float Rx = Uy * yawZ - Uz * yawY;
+            float Ry = Uz * yawX - Ux * yawZ;
+            float Rz = Ux * yawY - Uy * yawX;
+            float rLen = MathF.Sqrt(Rx * Rx + Ry * Ry + Rz * Rz);
             if (rLen < 1e-4f)
             {
                 Rx = 1f; Ry = 0f; Rz = 0f;
@@ -182,7 +176,7 @@ namespace KAMI.Core.Games
                 Rx /= rLen; Ry /= rLen; Rz /= rLen;
             }
 
-            // 2) Pitch around right vector R by -vertDiff (mouse down looks down)
+            // 2) Pitch around right vector R by vertDiff (mouse down looks down)
             var (pitchX, pitchY, pitchZ) = RotateAroundAxis(
                 yawX, yawY, yawZ,
                 Rx, Ry, Rz,

--- a/KAMI.Core/Games/Ratchet3PS2.cs
+++ b/KAMI.Core/Games/Ratchet3PS2.cs
@@ -4,6 +4,8 @@ namespace KAMI.Core.Games
 {
     public class Ratchet3PS2 : RatchetOGBase
     {
+        private uint m_addressScoped;
+
         public Ratchet3PS2(IntPtr ipc) : base(ipc)
         {
         }
@@ -15,6 +17,8 @@ namespace KAMI.Core.Games
             {
                 m_addressHor = 0x1A6160;
                 m_addressVert = 0x1A6180;
+                base.UpdateCamera(diffX, diffY);
+                return;
             }
             else
             {
@@ -23,56 +27,191 @@ namespace KAMI.Core.Games
                     case 40://Bakisi
                         m_addressHor = 0x300AA0;
                         m_addressVert = 0x300AC0;
+                        m_addressScoped = 0x3012CA;
                         break;
 
                     case 41://Hoven
                         m_addressHor = 0x300BE0;
                         m_addressVert = 0x300C00;
+                        m_addressScoped = 0x30140A;
                         break;
 
                     case 42://X12
                         m_addressHor = 0x2F8AE0;
                         m_addressVert = 0x2F8B00;
+                        m_addressScoped = 0x2F930A;
                         break;
 
                     case 43://Korgon
                         m_addressHor = 0x2F8960;
                         m_addressVert = 0x2F8980;
+                        m_addressScoped = 0x2F918A;
                         break;
 
                     case 44://Metro
                         m_addressHor = 0x2F89A0;
                         m_addressVert = 0x2F89C0;
+                        m_addressScoped = 0x2F91CA;
                         break;
 
                     case 45://BWC
                         m_addressHor = 0x2F8960;
                         m_addressVert = 0x2F8980;
+                        m_addressScoped = 0x2F918A;
                         break;
 
                     case 46://CC
                         m_addressHor = 0x309520;
                         m_addressVert = 0x309540;
+                        m_addressScoped = 0x309CCA;
                         break;
 
                     case 47://Dox
                         m_addressHor = 0x309660;
                         m_addressVert = 0x309680;
+                        m_addressScoped = 0x30A0AA;
                         break;
 
                     case 48://Sewers
                         m_addressHor = 0x3096A0;
                         m_addressVert = 0x3096C0;
+                        m_addressScoped = 0x30A0EA;
                         break;
 
                     case 49://Marcadia
                         m_addressHor = 0x309620;
                         m_addressVert = 0x309640;
+                        m_addressScoped = 0x309E4A;
                         break;
                 }
             }
+            m_camera.Hor = IPCUtils.ReadFloat(m_ipc, m_addressHor);
+            m_camera.Vert = IPCUtils.ReadFloat(m_ipc, m_addressVert);
 
-            base.UpdateCamera(diffX, diffY);
+            bool isScoped = IPCUtils.ReadU8(m_ipc, m_addressScoped) != 0;
+            float horDiff = -diffX * SensModifier;
+            float vertDiff = diffY * SensModifier;
+
+            if (isScoped)
+            {
+                horDiff *= ScopedSensModifier;
+                vertDiff *= ScopedSensModifier;
+            }
+
+            m_camera.Update(horDiff, vertDiff);
+
+            IPCUtils.WriteFloat(m_ipc, m_addressHor, m_camera.Hor);
+            IPCUtils.WriteFloat(m_ipc, m_addressVert, m_camera.Vert);
+
+            // Gravity-ramp directional camera update using character up vector
+            // Read current gravity camera direction (unit-ish vector)
+            float camX = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB0);
+            float camY = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB4);
+            float camZ = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB8);
+
+            // Read character up vector U = (Ux, Uy, Uz)
+            float Ux = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xA8);
+            float Uy = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0x98);
+            float Uz = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xB8);
+
+            // Normalize U
+            float uLen = MathF.Sqrt(Ux * Ux + Uy * Uy + Uz * Uz);
+            if (uLen < 1e-4f)
+            {
+                Ux = 0f; Uy = 0f; Uz = 1f;
+            }
+            else
+            {
+                Ux /= uLen; Uy /= uLen; Uz /= uLen;
+            }
+
+            // Normalize current direction D
+            float dLen = MathF.Sqrt(camX * camX + camY * camY + camZ * camZ);
+            if (dLen < 1e-4f)
+            {
+                camX = 1f; camY = 0f; camZ = 0f;
+            }
+            else
+            {
+                camX /= dLen; camY /= dLen; camZ /= dLen;
+            }
+
+            // Build right vector R = normalize(U x D)
+            float Rx = Uy * camZ - Uz * camY;
+            float Ry = Uz * camX - Ux * camZ;
+            float Rz = Ux * camY - Uy * camX;
+            float rLen = MathF.Sqrt(Rx * Rx + Ry * Ry + Rz * Rz);
+            if (rLen < 1e-4f)
+            {
+                // Degenerate (looking straight up/down) – pick any right perpendicular to U
+                Rx = 1f; Ry = 0f; Rz = 0f;
+            }
+            else
+            {
+                Rx /= rLen; Ry /= rLen; Rz /= rLen;
+            }
+
+            // 1) Yaw around up vector U by horDiff
+            var (yawX, yawY, yawZ) = RotateAroundAxis(
+                camX, camY, camZ,
+                Ux, Uy, Uz,
+                horDiff);
+
+            // Recompute right after yaw
+            Rx = Uy * yawZ - Uz * yawY;
+            Ry = Uz * yawX - Ux * yawZ;
+            Rz = Ux * yawY - Uy * yawX;
+            rLen = MathF.Sqrt(Rx * Rx + Ry * Ry + Rz * Rz);
+            if (rLen < 1e-4f)
+            {
+                Rx = 1f; Ry = 0f; Rz = 0f;
+            }
+            else
+            {
+                Rx /= rLen; Ry /= rLen; Rz /= rLen;
+            }
+
+            // 2) Pitch around right vector R by -vertDiff (mouse down looks down)
+            var (pitchX, pitchY, pitchZ) = RotateAroundAxis(
+                yawX, yawY, yawZ,
+                Rx, Ry, Rz,
+                vertDiff);
+
+            // Write back updated gravity camera direction
+            IPCUtils.WriteFloat(m_ipc, m_addressHor + 0xB0, pitchX);
+            IPCUtils.WriteFloat(m_ipc, m_addressHor + 0xB4, pitchY);
+            IPCUtils.WriteFloat(m_ipc, m_addressHor + 0xB8, pitchZ);
+        }
+
+        private static (float x, float y, float z) RotateAroundAxis(
+            float vx, float vy, float vz,
+            float ax, float ay, float az,
+            float angle)
+        {
+            float c = MathF.Cos(angle);
+            float s = MathF.Sin(angle);
+
+            // v_parallel = (v·a)a
+            float dot = vx * ax + vy * ay + vz * az;
+            float px = ax * dot;
+            float py = ay * dot;
+            float pz = az * dot;
+
+            // v_perp = v - v_parallel
+            float wx = vx - px;
+            float wy = vy - py;
+            float wz = vz - pz;
+
+            // a x v_perp
+            float cx = ay * wz - az * wy;
+            float cy = az * wx - ax * wz;
+            float cz = ax * wy - ay * wx;
+
+            // v' = v_parallel + v_perp * c + (a x v_perp) * s
+            float rx = px + wx * c + cx * s;
+            float ry = py + wy * c + cy * s;
+            float rz = pz + wz * c + cz * s;
+            return (rx, ry, rz);
         }
     }
 }

--- a/KAMI.Core/Games/Ratchet3PS2.cs
+++ b/KAMI.Core/Games/Ratchet3PS2.cs
@@ -6,12 +6,6 @@ namespace KAMI.Core.Games
     {
         private uint m_addressScoped;
         private bool isSinglePlayer;
-        
-        // Track last camera direction to filter jitter
-        private float lastCamX;
-        private float lastCamY;
-        private float lastCamZ;
-        private const float jitterThreadshold = 0.001f;
 
         public Ratchet3PS2(IntPtr ipc) : base(ipc)
         {
@@ -123,26 +117,9 @@ namespace KAMI.Core.Games
         private void UpdateGravityRampCamera(float horDiff, float vertDiff)
         {
             // Read current gravity camera direction (unit-ish vector)
-            float camX = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB0);
-            float camY = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB4);
-            float camZ = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB8);
-
-            // Check if camera direction has changed significantly (filter out jitter)
-            float deltaX = MathF.Abs(camX - lastCamX);
-            float deltaY = MathF.Abs(camY - lastCamY);
-            float deltaZ = MathF.Abs(camZ - lastCamZ);
-
-            // The game likes to litter the camera values ever so slightly while on a gravity ramp which causes random snapping
-            if (deltaX < jitterThreadshold && deltaY < jitterThreadshold && deltaZ < jitterThreadshold)
-            {
-                // Camera hasn't changed significantly, skip update
-                return;
-            }
-
-            // Update last known camera values
-            lastCamX = camX;
-            lastCamY = camY;
-            lastCamZ = camZ;
+            float camX = (float)Math.Round(IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB0), 5);
+            float camY = (float)Math.Round(IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB4), 5);
+            float camZ = (float)Math.Round(IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB8), 5);
 
             // Read character up vector U = (Ux, Uy, Uz)
             float Ux;

--- a/KAMI.Core/Games/Ratchet3PS2.cs
+++ b/KAMI.Core/Games/Ratchet3PS2.cs
@@ -5,7 +5,13 @@ namespace KAMI.Core.Games
     public class Ratchet3PS2 : RatchetOGBase
     {
         private uint m_addressScoped;
-        bool is_single_player;
+        private bool isSinglePlayer;
+        
+        // Track last camera direction to filter jitter
+        private float lastCamX;
+        private float lastCamY;
+        private float lastCamZ;
+        private const float jitterThreadshold = 0.001f;
 
         public Ratchet3PS2(IntPtr ipc) : base(ipc)
         {
@@ -14,8 +20,8 @@ namespace KAMI.Core.Games
         public override void UpdateCamera(int diffX, int diffY)
         {
             uint mp_map_id = IPCUtils.ReadU32(m_ipc, 0x001F8528);
-            is_single_player = mp_map_id < 40;
-            if (is_single_player) // must be SP
+            isSinglePlayer = mp_map_id < 40;
+            if (isSinglePlayer) // must be SP
             {
                 m_addressHor = 0x1A6160;
                 m_addressVert = 0x1A6180;
@@ -107,7 +113,11 @@ namespace KAMI.Core.Games
 
             // Gravity-ramp directional camera update using character up vector
             // Applied to both single player and multiplayer
-            UpdateGravityRampCamera(horDiff, vertDiff);
+            // Only update if there's actual input to avoid amplifying memory jitter
+            if (horDiff != 0f || vertDiff != 0f)
+            {
+                UpdateGravityRampCamera(horDiff, vertDiff);
+            }
         }
 
         private void UpdateGravityRampCamera(float horDiff, float vertDiff)
@@ -117,11 +127,28 @@ namespace KAMI.Core.Games
             float camY = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB4);
             float camZ = IPCUtils.ReadFloat(m_ipc, m_addressHor + 0xB8);
 
+            // Check if camera direction has changed significantly (filter out jitter)
+            float deltaX = MathF.Abs(camX - lastCamX);
+            float deltaY = MathF.Abs(camY - lastCamY);
+            float deltaZ = MathF.Abs(camZ - lastCamZ);
+
+            // The game likes to litter the camera values ever so slightly while on a gravity ramp which causes random snapping
+            if (deltaX < jitterThreadshold && deltaY < jitterThreadshold && deltaZ < jitterThreadshold)
+            {
+                // Camera hasn't changed significantly, skip update
+                return;
+            }
+
+            // Update last known camera values
+            lastCamX = camX;
+            lastCamY = camY;
+            lastCamZ = camZ;
+
             // Read character up vector U = (Ux, Uy, Uz)
             float Ux;
             float Uy;
             float Uz;
-            if (is_single_player)
+            if (isSinglePlayer)
             {
                 Ux = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xC8);
                 Uy = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xB8);
@@ -132,6 +159,13 @@ namespace KAMI.Core.Games
                 Ux = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xA8);
                 Uy = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0x98);
                 Uz = IPCUtils.ReadFloat(m_ipc, m_addressHor - 0xB8);
+            }
+
+            // if up vector is NaN or extremely large, skip update
+            if (float.IsNaN(Ux) || float.IsNaN(Uy) || float.IsNaN(Uz) ||
+                float.IsInfinity(Ux) || float.IsInfinity(Uy) || float.IsInfinity(Uz))
+            {
+                return;
             }
 
             // Normalize U
@@ -169,6 +203,7 @@ namespace KAMI.Core.Games
             float rLen = MathF.Sqrt(Rx * Rx + Ry * Ry + Rz * Rz);
             if (rLen < 1e-4f)
             {
+                // Degenerate (looking straight up/down) – pick any right perpendicular to U
                 Rx = 1f; Ry = 0f; Rz = 0f;
             }
             else
@@ -181,6 +216,13 @@ namespace KAMI.Core.Games
                 yawX, yawY, yawZ,
                 Rx, Ry, Rz,
                 vertDiff);
+
+            // if result is NaN or infinite, skip write
+            if (float.IsNaN(pitchX) || float.IsNaN(pitchY) || float.IsNaN(pitchZ) ||
+                float.IsInfinity(pitchX) || float.IsInfinity(pitchY) || float.IsInfinity(pitchZ))
+            {
+                return;
+            }
 
             // Write back updated gravity camera direction
             IPCUtils.WriteFloat(m_ipc, m_addressHor + 0xB0, pitchX);

--- a/KAMI.Core/Games/Ratchet3PS2.cs
+++ b/KAMI.Core/Games/Ratchet3PS2.cs
@@ -5,6 +5,7 @@ namespace KAMI.Core.Games
     public class Ratchet3PS2 : RatchetOGBase
     {
         private uint m_addressScoped;
+        private bool isScoped;
 
         public Ratchet3PS2(IntPtr ipc) : base(ipc)
         {
@@ -17,6 +18,16 @@ namespace KAMI.Core.Games
             {
                 m_addressHor = 0x1A6160;
                 m_addressVert = 0x1A6180;
+                m_addressScoped = 0x1A71C5;
+
+                isScoped = IPCUtils.ReadU8(m_ipc, m_addressScoped) != 0;
+
+                if (isScoped)
+                {
+                    diffX = (int)(diffX * ScopedSensModifier);
+                    diffY = (int)(diffY * ScopedSensModifier);
+                }
+
                 base.UpdateCamera(diffX, diffY);
                 return;
             }
@@ -88,7 +99,7 @@ namespace KAMI.Core.Games
             m_camera.Hor = IPCUtils.ReadFloat(m_ipc, m_addressHor);
             m_camera.Vert = IPCUtils.ReadFloat(m_ipc, m_addressVert);
 
-            bool isScoped = IPCUtils.ReadU8(m_ipc, m_addressScoped) != 0;
+            isScoped = IPCUtils.ReadU8(m_ipc, m_addressScoped) != 0;
             float horDiff = -diffX * SensModifier;
             float vertDiff = diffY * SensModifier;
 

--- a/KAMI.Core/Games/RatchetOGBase.cs
+++ b/KAMI.Core/Games/RatchetOGBase.cs
@@ -16,7 +16,12 @@ namespace KAMI.Core.Games
         {
             m_camera.Hor = IPCUtils.ReadFloat(m_ipc, m_addressHor);
             m_camera.Vert = IPCUtils.ReadFloat(m_ipc, m_addressVert);
-            m_camera.Update(-diffX * SensModifier, diffY * SensModifier);
+
+            float horDiff = -diffX * SensModifier;
+            float vertDiff = diffY * SensModifier;
+
+            m_camera.Update(horDiff, vertDiff);
+
             IPCUtils.WriteFloat(m_ipc, m_addressHor, m_camera.Hor);
             IPCUtils.WriteFloat(m_ipc, m_addressVert, m_camera.Vert);
         }

--- a/KAMI.Core/IPCUtils.cs
+++ b/KAMI.Core/IPCUtils.cs
@@ -47,5 +47,11 @@ namespace KAMI.Core
             Write(ipc, address, value, IPCCommand.MsgWrite16);
             Error = GetError(ipc);
         }
+        public static byte ReadU8(IntPtr ipc, uint address)
+        {
+            byte value = (byte)Read(ipc, address, IPCCommand.MsgRead8);
+            Error = GetError(ipc);
+            return value;
+        }
     }
 }

--- a/KAMI.Core/KAMICore.cs
+++ b/KAMI.Core/KAMICore.cs
@@ -99,6 +99,7 @@ namespace KAMI.Core
             if (m_game != null)
             {
                 m_game.SensModifier = Config.Sensitivity;
+                m_game.ScopedSensModifier = Config.ScopedSensitivity;
             }
 
             m_mouseHandler = Config.MouseHandler switch
@@ -139,6 +140,15 @@ namespace KAMI.Core
             if (m_game != null)
             {
                 m_game.SensModifier = sensitivity;
+            }
+        }
+        public void SetScopedSensitivity(float scopedSensitivity)
+        {
+            Config.ScopedSensitivity = scopedSensitivity;
+            m_configManager.WriteConfig();
+            if (m_game != null)
+            {
+                m_game.ScopedSensModifier = scopedSensitivity;
             }
         }
 
@@ -251,6 +261,7 @@ namespace KAMI.Core
                         string gameVersion = PineIPC.GetGameVersion(m_ipc);
                         m_game = m_gameManager.GetGame(m_ipc, titleId, gameVersion);
                         m_game.SensModifier = Config.Sensitivity;
+                        m_game.ScopedSensModifier = Config.ScopedSensitivity;
                     }
                     break;
                 case KAMIStatus.Ready:
@@ -271,6 +282,7 @@ namespace KAMI.Core
                         {
                             m_game = m_gameManager.GetGame(m_ipc, titleId, gameVersion);
                             m_game.SensModifier = Config.Sensitivity;
+                            m_game.ScopedSensModifier = Config.ScopedSensitivity;
                         }
                     }
                     break;
@@ -315,7 +327,7 @@ namespace KAMI.Core
                     }
                     else
                     {
-                        Thread.Sleep(8);
+                        Thread.Sleep(5);
                     }
                 }
                 catch (Exception ex)

--- a/KAMI.Core/KAMICore.cs
+++ b/KAMI.Core/KAMICore.cs
@@ -327,7 +327,7 @@ namespace KAMI.Core
                     }
                     else
                     {
-                        Thread.Sleep(5);
+                        Thread.Sleep(8);
                     }
                 }
                 catch (Exception ex)

--- a/KAMI.Core/KamiConfig.cs
+++ b/KAMI.Core/KamiConfig.cs
@@ -8,18 +8,20 @@ namespace KAMI.Core
         public int? Mouse1Key { get; internal set; }
         public int? Mouse2Key { get; internal set; }
         public float Sensitivity { get; internal set; }
+        public float ScopedSensitivity { get; internal set; }
         public bool HideCursor { get; internal set; }
         public MouseHandlerEnum MouseHandler { get; internal set; }
         public bool UsePCSX2 { get; internal set; }
         public bool InvertX { get; internal set; }
         public bool InvertY { get; internal set; }
 
-        public KamiConfig(int? toggleKey, int? mouse1Key, int? mouse2Key, float sensitivity, bool hideCursor, MouseHandlerEnum mouseHandler, bool usePCSX2, bool invertX, bool invertY)
+        public KamiConfig(int? toggleKey, int? mouse1Key, int? mouse2Key, float sensitivity, float scopedSensitivity, bool hideCursor, MouseHandlerEnum mouseHandler, bool usePCSX2, bool invertX, bool invertY)
         {
             ToggleKey = toggleKey;
             Mouse1Key = mouse1Key;
             Mouse2Key = mouse2Key;
             Sensitivity = sensitivity;
+            ScopedSensitivity = scopedSensitivity;
             HideCursor = hideCursor;
             MouseHandler = mouseHandler;
             UsePCSX2 = usePCSX2;
@@ -35,6 +37,7 @@ namespace KAMI.Core
                 mouse1Key: null,
                 mouse2Key: null,
                 sensitivity: 0.003f,
+                scopedSensitivity: 1.0f,
                 hideCursor: false,
                 mouseHandler: MouseHandlerEnum.Cursor,
                 usePCSX2: false,

--- a/KAMI.Windows/MainWindow.xaml
+++ b/KAMI.Windows/MainWindow.xaml
@@ -5,23 +5,26 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:KAMI"
         mc:Ignorable="d"
-        Title="Kot And Mouse Injector" Height="276" Width="331" Loaded="Window_Loaded" Closing="Window_Closing">
+        Title="Kot And Mouse Injector" Height="335" Width="335" Loaded="Window_Loaded" Closing="Window_Closing">
     <Grid>
         <Label x:Name="statusLabel" Content="KAMI Status: Off" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
         <Label x:Name="buttonLabel" Content="On/Off Button: " HorizontalAlignment="Left" Margin="10,41,0,0" VerticalAlignment="Top"/>
         <Button x:Name="toggleButton" Content="Unbound" HorizontalAlignment="Left" Margin="107,44,0,0" VerticalAlignment="Top" Width="59" Click="toggleButton_Click" KeyDown="toggleButton_KeyDown" LostFocus="toggleButton_LostFocus"/>
         <Label x:Name="sensitivityLabel" Content="Sensitivity: " HorizontalAlignment="Left" Margin="10,72,0,0" VerticalAlignment="Top"/>
-        <TextBox x:Name="sensitivityTextBox" HorizontalAlignment="Left" Margin="84,76,0,0" Text="0.003" TextWrapping="Wrap" VerticalAlignment="Top" Width="120" TextChanged="sensitivityTextBox_TextChanged"/>
-        <Label x:Name="infoLabel" Content="Info:" HorizontalAlignment="Left" Margin="10,143,0,0" VerticalAlignment="Top" RenderTransformOrigin="0.574,0.139"/>
-        <Ellipse x:Name="sensitivityEllipse" HorizontalAlignment="Left" Height="18" Margin="209,76,0,0" VerticalAlignment="Top" Width="18" Fill="DarkGreen"/>
+        <TextBox x:Name="sensitivityTextBox" HorizontalAlignment="Left" Margin="121,76,0,0" Text="0.003" TextWrapping="Wrap" VerticalAlignment="Top" Width="120" TextChanged="sensitivityTextBox_TextChanged"/>
+        <TextBox x:Name="scopedSensitivityTextBox" HorizontalAlignment="Left" Margin="121,99,0,0" Text="1.000" TextWrapping="Wrap" VerticalAlignment="Top" Width="120" TextChanged="scopedSensitivityTextBox_TextChanged"/>
+        <Label x:Name="infoLabel" Content="Info:" HorizontalAlignment="Left" Margin="11,183,0,0" VerticalAlignment="Top" RenderTransformOrigin="0.574,0.139"/>
+        <Ellipse x:Name="sensitivityEllipse" HorizontalAlignment="Left" Height="18" Margin="251,76,0,0" VerticalAlignment="Top" Width="18" Fill="DarkGreen"/>
         <Button x:Name="mouse1Button" Content="Unbound" HorizontalAlignment="Left" Margin="251,10,0,0" VerticalAlignment="Top" Click="mouse1Button_Click" KeyDown="mouse1Button_KeyDown" LostFocus="mouse1Button_LostFocus"/>
         <Button x:Name="mouse2Button" Content="Unbound" HorizontalAlignment="Left" Margin="251,35,0,0" VerticalAlignment="Top" Click="mouse2Button_Click" KeyDown="mouse2Button_KeyDown" LostFocus="mouse2Button_LostFocus"/>
         <Label x:Name="mouse1Label" Content="Mouse1:" HorizontalAlignment="Left" Margin="191,7,0,0" VerticalAlignment="Top"/>
         <Label x:Name="mouse2Label" Content="Mouse2:" HorizontalAlignment="Left" Margin="191,32,0,0" VerticalAlignment="Top"/>
-        <CheckBox x:Name="mouseCursorCheckBox" Content="Hide mouse cursor" HorizontalAlignment="Left" Margin="10,104,0,0" VerticalAlignment="Top" Checked="mouseCursorCheckBox_Checked" Unchecked="mouseCursorCheckBox_Unchecked"/>
-        <CheckBox x:Name="pcsx2CheckBox" Content="Use PCSX2" HorizontalAlignment="Left" Margin="10,126,0,0" VerticalAlignment="Top" Checked="pcsx2CheckBox_Checked" Unchecked="pcsx2CheckBox_Unchecked"/>
-        <CheckBox x:Name="invertXCheckBox" Content="Invert X" HorizontalAlignment="Left" Margin="201,104,0,0" VerticalAlignment="Top" Checked="invertXCheckBox_Checked" Unchecked="invertXCheckBox_Unchecked"/>
-        <CheckBox x:Name="invertYCheckBox" Content="Invert Y" HorizontalAlignment="Left" Margin="201,126,0,0" VerticalAlignment="Top" Checked="invertYCheckBox_Checked" Unchecked="invertYCheckBox_Unchecked"/>
+        <CheckBox x:Name="mouseCursorCheckBox" Content="Hide mouse cursor" HorizontalAlignment="Left" Margin="10,120,0,0" VerticalAlignment="Top" Checked="mouseCursorCheckBox_Checked" Unchecked="mouseCursorCheckBox_Unchecked"/>
+        <CheckBox x:Name="pcsx2CheckBox" Content="Use PCSX2" HorizontalAlignment="Left" Margin="10,140,0,0" VerticalAlignment="Top" Checked="pcsx2CheckBox_Checked" Unchecked="pcsx2CheckBox_Unchecked"/>
+        <CheckBox x:Name="invertXCheckBox" Content="Invert X" HorizontalAlignment="Left" Margin="201,120,0,0" VerticalAlignment="Top" Checked="invertXCheckBox_Checked" Unchecked="invertXCheckBox_Unchecked"/>
+        <CheckBox x:Name="invertYCheckBox" Content="Invert Y" HorizontalAlignment="Left" Margin="201,140,0,0" VerticalAlignment="Top" Checked="invertYCheckBox_Checked" Unchecked="invertYCheckBox_Unchecked"/>
+        <Ellipse x:Name="scopedSensitivityEllipse" HorizontalAlignment="Left" Height="18" Margin="251,99,0,0" VerticalAlignment="Top" Width="18" Fill="DarkGreen"/>
+        <Label x:Name="scopedSensitivityLabel" Content="Scoped Sensitivity: " HorizontalAlignment="Left" Margin="10,94,0,0" VerticalAlignment="Top"/>
 
     </Grid>
 </Window>

--- a/KAMI.Windows/MainWindow.xaml.cs
+++ b/KAMI.Windows/MainWindow.xaml.cs
@@ -37,6 +37,7 @@ namespace KAMI.Windows
                 mouse1Button.Content = FromVKey(m_kami.Config.Mouse1Key)?.ToString() ?? "Unbound";
                 mouse2Button.Content = FromVKey(m_kami.Config.Mouse2Key)?.ToString() ?? "Unbound";
                 sensitivityTextBox.Text = m_kami.Config.Sensitivity.ToString(CultureInfo.InvariantCulture);
+                scopedSensitivityTextBox.Text = m_kami.Config.ScopedSensitivity.ToString(CultureInfo.InvariantCulture);
                 mouseCursorCheckBox.IsChecked = m_kami.Config.HideCursor;
                 pcsx2CheckBox.IsChecked = m_kami.Config.UsePCSX2;
                 invertXCheckBox.IsChecked = m_kami.Config.InvertX;
@@ -140,6 +141,18 @@ namespace KAMI.Windows
             else if (sensitivityEllipse != null)
             {
                 sensitivityEllipse.Fill = new SolidColorBrush(Color.FromRgb(100, 0, 0));
+            }
+        }
+        private void scopedSensitivityTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (scopedSensitivityEllipse != null && float.TryParse(scopedSensitivityTextBox.Text, NumberStyles.Any, CultureInfo.InvariantCulture, out float scopedSensitivity))
+            {
+                m_kami.SetScopedSensitivity(scopedSensitivity);
+                scopedSensitivityEllipse.Fill = new SolidColorBrush(Color.FromRgb(0, 100, 0));
+            }
+            else if (scopedSensitivityEllipse != null)
+            {
+                scopedSensitivityEllipse.Fill = new SolidColorBrush(Color.FromRgb(100, 0, 0));
             }
         }
 


### PR DESCRIPTION
About 6 months ago I was heavily invested in RAC3 multiplayer so I made a fork of this in order add scoped sensitivity but also to address the cameras locking problem (same issue as #105 ) on gravity ramps or landing with swingshot.

I wanted to open this PR to see if this could get this added as a part of the base program, but I right now scoped sensitivity setting in the GUI is always visible regardless of whether you are connected to RAC3 or not, so this is where I could use some help. to finalize it.